### PR TITLE
Update(docs): add eliza memeooorr agent link

### DIFF
--- a/docs/olas-sdk/index.md
+++ b/docs/olas-sdk/index.md
@@ -15,7 +15,7 @@ Here you can see the examples of two agents built with different frameworks:
 
 - [Langchain Hello World Agent](https://github.com/valory-xyz/langchain_hello_world)
 
-- Eliza Memeooorr Agent (link to repo will be added soon)
+- [Eliza Memeooorr Agent](https://github.com/valory-xyz/agents-fun-eliza)
 
 ## Step 2: Olas Agent and Service Configuration
 Once the agent is ready, the next step is to configure the Olas Agent and Service. 


### PR DESCRIPTION
This pull request includes a minor update to the `docs/olas-sdk/index.md` file. The change updates the link for the Eliza Memeooorr Agent to point to its repository on GitHub.

* [`docs/olas-sdk/index.md`](diffhunk://#diff-fb071d32631aa8931f0b2c38fe6c663108cfbffa7614a985592722cacfa667a0L18-R18): Updated the link for the Eliza Memeooorr Agent to `https://github.com/valory-xyz/agents-fun-eliza`