### PR TITLE
chore: incorrect docs link

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -1,7 +1,7 @@
 # Olas Stack Developer Documentation
 
 This documentation covers the technical building blocks that make up Olas. For a higher level
-documentation on "what is Olas" visit [Olas documentation](https://docs.autonolas.network/) instead.
+documentation on "what is Olas" visit [Olas documentation](https://docs.olas.network/) instead.
 
 ## The Olas Stack
 


### PR DESCRIPTION
## Changes

Link **Olas Documentation** (docs.autonolas.network => docs.olas.network)