### PR TITLE
fix: recognize uv and modern Poetry dependency formats in the dependency graph

### DIFF
--- a/docs/dependency_graph.md
+++ b/docs/dependency_graph.md
@@ -20,7 +20,6 @@ flowchart LR
     brand_and_press_kit_pearl["brand-and-press-kit-pearl"]
     dev_template["dev-template"]
     docs["docs"]
-    dynamic_contribution["dynamic-contribution"]
     funds_manager["funds-manager"]
     genai["genai"]
     governance_near["governance-near"]
@@ -77,7 +76,6 @@ flowchart LR
     click brand_and_press_kit_pearl "https://github.com/valory-xyz/brand-and-press-kit-pearl" "Press Kit summarizing Brand Guidelines (inc. logos) and Information about Pearl (e.g. for Press Releases)" _blank
     click dev_template "https://github.com/valory-xyz/dev-template" "A template for development with the open-autonomy framework." _blank
     click docs "https://github.com/valory-xyz/docs" "This repository aggregates the documentation of all the Olas ecosystem products." _blank
-    click dynamic_contribution "https://github.com/valory-xyz/dynamic-contribution" "This repository contains the Autonolas dynamic contribution contracts." _blank
     click funds_manager "https://github.com/valory-xyz/funds-manager" "Open Autonomy library skill for funding mechanism" _blank
     click genai "https://github.com/valory-xyz/genai" "Open Autonomy library skill wrapping generative AI" _blank
     click governance_near "https://github.com/valory-xyz/governance-near" "Autonolas governance contracts on Near" _blank
@@ -135,52 +133,52 @@ flowchart LR
     docs -->|<a href="https://github.com/valory-xyz/docs/blob/main/.gitmodules#L13" target="_blank">Link</a>| open_aea
     docs -->|<a href="https://github.com/valory-xyz/docs/blob/main/.gitmodules#L1" target="_blank">Link</a>| open_autonomy
     docs -->|<a href="https://github.com/valory-xyz/docs/blob/main/pyproject.toml#L9" target="_blank">Link</a>| tomte
-    funds_manager -->|<a href="https://github.com/valory-xyz/funds-manager/blob/main/pyproject.toml#L13" target="_blank">Link</a>| open_aea
+    funds_manager -->|<a href="https://github.com/valory-xyz/funds-manager/blob/main/pyproject.toml#L15" target="_blank">Link</a>| open_aea
     funds_manager -->|<a href="https://github.com/valory-xyz/funds-manager/blob/main/pyproject.toml#L14" target="_blank">Link</a>| open_autonomy
     funds_manager -->|<a href="https://github.com/valory-xyz/funds-manager/blob/main/pyproject.toml#L49" target="_blank">Link</a>| tomte
-    genai -->|<a href="https://github.com/valory-xyz/genai/blob/main/pyproject.toml#L13" target="_blank">Link</a>| open_aea
+    genai -->|<a href="https://github.com/valory-xyz/genai/blob/main/pyproject.toml#L15" target="_blank">Link</a>| open_aea
     genai -->|<a href="https://github.com/valory-xyz/genai/blob/main/pyproject.toml#L14" target="_blank">Link</a>| open_autonomy
     genai -->|<a href="https://github.com/valory-xyz/genai/blob/main/pyproject.toml#L50" target="_blank">Link</a>| tomte
     hello_world -->|<a href="https://github.com/valory-xyz/hello-world/blob/main/pyproject.toml#L13" target="_blank">Link</a>| open_aea
     hello_world -->|<a href="https://github.com/valory-xyz/hello-world/blob/main/pyproject.toml#L18" target="_blank">Link</a>| open_autonomy
     hello_world -->|<a href="https://github.com/valory-xyz/hello-world/blob/main/pyproject.toml#L53" target="_blank">Link</a>| tomte
-    kv_store -->|<a href="https://github.com/valory-xyz/kv-store/blob/main/pyproject.toml#L13" target="_blank">Link</a>| open_aea
+    kv_store -->|<a href="https://github.com/valory-xyz/kv-store/blob/main/pyproject.toml#L15" target="_blank">Link</a>| open_aea
     kv_store -->|<a href="https://github.com/valory-xyz/kv-store/blob/main/pyproject.toml#L14" target="_blank">Link</a>| open_autonomy
     kv_store -->|<a href="https://github.com/valory-xyz/kv-store/blob/main/pyproject.toml#L42" target="_blank">Link</a>| tomte
-    market_creator -->|<a href="https://github.com/valory-xyz/market-creator/blob/main/pyproject.toml#L68" target="_blank">Link</a>| genai
-    market_creator -->|<a href="https://github.com/valory-xyz/market-creator/blob/main/pyproject.toml#L68" target="_blank">Link</a>| mech_interact
-    market_creator -->|<a href="https://github.com/valory-xyz/market-creator/blob/main/pyproject.toml#L68" target="_blank">Link</a>| omen_protocol
+    market_creator -->|<a href="https://github.com/valory-xyz/market-creator/blob/main/pyproject.toml#L73" target="_blank">Link</a>| genai
+    market_creator -->|<a href="https://github.com/valory-xyz/market-creator/blob/main/pyproject.toml#L72" target="_blank">Link</a>| mech_interact
+    market_creator -->|<a href="https://github.com/valory-xyz/market-creator/blob/main/pyproject.toml#L74" target="_blank">Link</a>| omen_protocol
     market_creator -->|<a href="https://github.com/valory-xyz/market-creator/blob/main/pyproject.toml#L19" target="_blank">Link</a>| open_aea
     market_creator -->|<a href="https://github.com/valory-xyz/market-creator/blob/main/pyproject.toml#L13" target="_blank">Link</a>| open_autonomy
     market_creator -->|<a href="https://github.com/valory-xyz/market-creator/blob/main/pyproject.toml#L59" target="_blank">Link</a>| tomte
-    market_resolver -->|<a href="https://github.com/valory-xyz/market-resolver/blob/main/pyproject.toml#L64" target="_blank">Link</a>| genai
-    market_resolver -->|<a href="https://github.com/valory-xyz/market-resolver/blob/main/pyproject.toml#L62" target="_blank">Link</a>| mech_interact
-    market_resolver -->|<a href="https://github.com/valory-xyz/market-resolver/blob/main/pyproject.toml#L63" target="_blank">Link</a>| omen_protocol
+    market_resolver -->|<a href="https://github.com/valory-xyz/market-resolver/blob/main/pyproject.toml#L69" target="_blank">Link</a>| genai
+    market_resolver -->|<a href="https://github.com/valory-xyz/market-resolver/blob/main/pyproject.toml#L67" target="_blank">Link</a>| mech_interact
+    market_resolver -->|<a href="https://github.com/valory-xyz/market-resolver/blob/main/pyproject.toml#L68" target="_blank">Link</a>| omen_protocol
     market_resolver -->|<a href="https://github.com/valory-xyz/market-resolver/blob/main/pyproject.toml#L18" target="_blank">Link</a>| open_aea
     market_resolver -->|<a href="https://github.com/valory-xyz/market-resolver/blob/main/pyproject.toml#L13" target="_blank">Link</a>| open_autonomy
     market_resolver -->|<a href="https://github.com/valory-xyz/market-resolver/blob/main/pyproject.toml#L52" target="_blank">Link</a>| tomte
     mech -->|<a href="https://github.com/valory-xyz/mech/blob/main/pyproject.toml#L15" target="_blank">Link</a>| open_aea
     mech -->|<a href="https://github.com/valory-xyz/mech/blob/main/pyproject.toml#L14" target="_blank">Link</a>| open_autonomy
-    mech -->|<a href="https://github.com/valory-xyz/mech/blob/main/pyproject.toml#L50" target="_blank">Link</a>| tomte
+    mech -->|<a href="https://github.com/valory-xyz/mech/blob/main/pyproject.toml#L51" target="_blank">Link</a>| tomte
     mech_agents_fun -->|<a href="https://github.com/valory-xyz/mech-agents-fun/blob/main/pyproject.toml#L59" target="_blank">Link</a>| mech
-    mech_agents_fun -->|<a href="https://github.com/valory-xyz/mech-agents-fun/blob/main/pyproject.toml#L13" target="_blank">Link</a>| open_aea
+    mech_agents_fun -->|<a href="https://github.com/valory-xyz/mech-agents-fun/blob/main/pyproject.toml#L15" target="_blank">Link</a>| open_aea
     mech_agents_fun -->|<a href="https://github.com/valory-xyz/mech-agents-fun/blob/main/pyproject.toml#L14" target="_blank">Link</a>| open_autonomy
     mech_agents_fun -->|<a href="https://github.com/valory-xyz/mech-agents-fun/blob/main/pyproject.toml#L64" target="_blank">Link</a>| tomte
     mech_client -->|<a href="https://github.com/valory-xyz/mech-client/blob/main/pyproject.toml#L13" target="_blank">Link</a>| olas_operate_middleware
     mech_client -->|<a href="https://github.com/valory-xyz/mech-client/blob/main/packages/packages.json#L8" target="_blank">Link</a>| open_aea
     mech_client -->|<a href="https://github.com/valory-xyz/mech-client/blob/main/pyproject.toml#L9" target="_blank">Link</a>| open_autonomy
-    mech_client -->|<a href="https://github.com/valory-xyz/mech-client/blob/main/pyproject.toml#L33" target="_blank">Link</a>| tomte
+    mech_client -->|<a href="https://github.com/valory-xyz/mech-client/blob/main/pyproject.toml#L34" target="_blank">Link</a>| tomte
     mech_interact -->|<a href="https://github.com/valory-xyz/mech-interact/blob/main/pyproject.toml#L14" target="_blank">Link</a>| open_aea
     mech_interact -->|<a href="https://github.com/valory-xyz/mech-interact/blob/main/pyproject.toml#L13" target="_blank">Link</a>| open_autonomy
-    mech_interact -->|<a href="https://github.com/valory-xyz/mech-interact/blob/main/pyproject.toml#L50" target="_blank">Link</a>| tomte
+    mech_interact -->|<a href="https://github.com/valory-xyz/mech-interact/blob/main/pyproject.toml#L51" target="_blank">Link</a>| tomte
     mech_predict -->|<a href="https://github.com/valory-xyz/mech-predict/blob/main/pyproject.toml#L6" target="_blank">Link</a>| mech
-    mech_predict -->|<a href="https://github.com/valory-xyz/mech-predict/blob/main/pyproject.toml#L13" target="_blank">Link</a>| open_aea
+    mech_predict -->|<a href="https://github.com/valory-xyz/mech-predict/blob/main/pyproject.toml#L15" target="_blank">Link</a>| open_aea
     mech_predict -->|<a href="https://github.com/valory-xyz/mech-predict/blob/main/pyproject.toml#L14" target="_blank">Link</a>| open_autonomy
     mech_predict -->|<a href="https://github.com/valory-xyz/mech-predict/blob/main/pyproject.toml#L91" target="_blank">Link</a>| tomte
     mech_server -->|<a href="https://github.com/valory-xyz/mech-server/blob/main/pyproject.toml#L6" target="_blank">Link</a>| mech
     mech_server -->|<a href="https://github.com/valory-xyz/mech-server/blob/main/pyproject.toml#L47" target="_blank">Link</a>| mech_client
-    mech_server -->|<a href="https://github.com/valory-xyz/mech-server/blob/main/pyproject.toml#L43" target="_blank">Link</a>| olas_operate_middleware
-    mech_server -->|<a href="https://github.com/valory-xyz/mech-server/blob/main/pyproject.toml#L13" target="_blank">Link</a>| open_aea
+    mech_server -->|<a href="https://github.com/valory-xyz/mech-server/blob/main/pyproject.toml#L48" target="_blank">Link</a>| olas_operate_middleware
+    mech_server -->|<a href="https://github.com/valory-xyz/mech-server/blob/main/pyproject.toml#L15" target="_blank">Link</a>| open_aea
     mech_server -->|<a href="https://github.com/valory-xyz/mech-server/blob/main/pyproject.toml#L14" target="_blank">Link</a>| open_autonomy
     mech_server -->|<a href="https://github.com/valory-xyz/mech-server/blob/main/pyproject.toml#L66" target="_blank">Link</a>| tomte
     meme_ooorr -->|<a href="https://github.com/valory-xyz/meme-ooorr/blob/main/pyproject.toml#L64" target="_blank">Link</a>| funds_manager
@@ -203,7 +201,7 @@ flowchart LR
     omen_protocol -->|<a href="https://github.com/valory-xyz/omen-protocol/blob/main/pyproject.toml#L13" target="_blank">Link</a>| open_autonomy
     omen_protocol -->|<a href="https://github.com/valory-xyz/omen-protocol/blob/main/pyproject.toml#L49" target="_blank">Link</a>| tomte
     open_aea -->|<a href="https://github.com/valory-xyz/open-aea/blob/main/pyproject.toml#L57" target="_blank">Link</a>| tomte
-    open_autonomy -->|<a href="https://github.com/valory-xyz/open-autonomy/blob/main/setup.py#L32" target="_blank">Link</a>| open_aea
+    open_autonomy -->|<a href="https://github.com/valory-xyz/open-autonomy/blob/main/setup.py#L35" target="_blank">Link</a>| open_aea
     open_autonomy -->|<a href="https://github.com/valory-xyz/open-autonomy/blob/main/pyproject.toml#L107" target="_blank">Link</a>| tomte
     optimus -->|<a href="https://github.com/valory-xyz/optimus/blob/main/pyproject.toml#L70" target="_blank">Link</a>| funds_manager
     optimus -->|<a href="https://github.com/valory-xyz/optimus/blob/main/pyproject.toml#L68" target="_blank">Link</a>| genai

--- a/docs/dependency_graph.md
+++ b/docs/dependency_graph.md
@@ -125,7 +125,9 @@ flowchart LR
     autonolas_v1 -->|<a href="https://github.com/valory-xyz/autonolas-v1/blob/main/remappings.txt#L4" target="_blank">Link</a>| autonolas_registries
     autonolas_v1 -->|<a href="https://github.com/valory-xyz/autonolas-v1/blob/main/.gitmodules#L16" target="_blank">Link</a>| autonolas_staking_programmes
     autonolas_v1 -->|<a href="https://github.com/valory-xyz/autonolas-v1/blob/main/remappings.txt#L2" target="_blank">Link</a>| autonolas_tokenomics
+    dev_template -->|<a href="https://github.com/valory-xyz/dev-template/blob/main/pyproject.toml#L25" target="_blank">Link</a>| open_aea
     dev_template -->|<a href="https://github.com/valory-xyz/dev-template/blob/main/pyproject.toml#L13" target="_blank">Link</a>| open_autonomy
+    dev_template -->|<a href="https://github.com/valory-xyz/dev-template/blob/main/pyproject.toml#L22" target="_blank">Link</a>| tomte
     docs -->|<a href="https://github.com/valory-xyz/docs/blob/main/.gitmodules#L10" target="_blank">Link</a>| hello_world
     docs -->|<a href="https://github.com/valory-xyz/docs/blob/main/.gitmodules#L4" target="_blank">Link</a>| mech
     docs -->|<a href="https://github.com/valory-xyz/docs/blob/main/.gitmodules#L19" target="_blank">Link</a>| mech_server
@@ -135,73 +137,96 @@ flowchart LR
     docs -->|<a href="https://github.com/valory-xyz/docs/blob/main/pyproject.toml#L9" target="_blank">Link</a>| tomte
     funds_manager -->|<a href="https://github.com/valory-xyz/funds-manager/blob/main/pyproject.toml#L13" target="_blank">Link</a>| open_aea
     funds_manager -->|<a href="https://github.com/valory-xyz/funds-manager/blob/main/pyproject.toml#L14" target="_blank">Link</a>| open_autonomy
+    funds_manager -->|<a href="https://github.com/valory-xyz/funds-manager/blob/main/pyproject.toml#L49" target="_blank">Link</a>| tomte
     genai -->|<a href="https://github.com/valory-xyz/genai/blob/main/pyproject.toml#L13" target="_blank">Link</a>| open_aea
     genai -->|<a href="https://github.com/valory-xyz/genai/blob/main/pyproject.toml#L14" target="_blank">Link</a>| open_autonomy
+    genai -->|<a href="https://github.com/valory-xyz/genai/blob/main/pyproject.toml#L50" target="_blank">Link</a>| tomte
     hello_world -->|<a href="https://github.com/valory-xyz/hello-world/blob/main/pyproject.toml#L13" target="_blank">Link</a>| open_aea
     hello_world -->|<a href="https://github.com/valory-xyz/hello-world/blob/main/pyproject.toml#L18" target="_blank">Link</a>| open_autonomy
+    hello_world -->|<a href="https://github.com/valory-xyz/hello-world/blob/main/pyproject.toml#L53" target="_blank">Link</a>| tomte
     kv_store -->|<a href="https://github.com/valory-xyz/kv-store/blob/main/pyproject.toml#L13" target="_blank">Link</a>| open_aea
     kv_store -->|<a href="https://github.com/valory-xyz/kv-store/blob/main/pyproject.toml#L14" target="_blank">Link</a>| open_autonomy
-    market_creator -->|<a href="https://github.com/valory-xyz/market-creator/blob/main/packages/packages.json#L19" target="_blank">Link</a>| genai
-    market_creator -->|<a href="https://github.com/valory-xyz/market-creator/blob/main/packages/packages.json#L30" target="_blank">Link</a>| mech_interact
-    market_creator -->|<a href="https://github.com/valory-xyz/market-creator/blob/main/packages/packages.json#L21" target="_blank">Link</a>| omen_protocol
+    kv_store -->|<a href="https://github.com/valory-xyz/kv-store/blob/main/pyproject.toml#L42" target="_blank">Link</a>| tomte
+    market_creator -->|<a href="https://github.com/valory-xyz/market-creator/blob/main/pyproject.toml#L68" target="_blank">Link</a>| genai
+    market_creator -->|<a href="https://github.com/valory-xyz/market-creator/blob/main/pyproject.toml#L68" target="_blank">Link</a>| mech_interact
+    market_creator -->|<a href="https://github.com/valory-xyz/market-creator/blob/main/pyproject.toml#L68" target="_blank">Link</a>| omen_protocol
     market_creator -->|<a href="https://github.com/valory-xyz/market-creator/blob/main/pyproject.toml#L19" target="_blank">Link</a>| open_aea
     market_creator -->|<a href="https://github.com/valory-xyz/market-creator/blob/main/pyproject.toml#L13" target="_blank">Link</a>| open_autonomy
-    market_resolver -->|<a href="https://github.com/valory-xyz/market-resolver/blob/main/packages/packages.json#L18" target="_blank">Link</a>| genai
-    market_resolver -->|<a href="https://github.com/valory-xyz/market-resolver/blob/main/packages/packages.json#L20" target="_blank">Link</a>| mech_interact
-    market_resolver -->|<a href="https://github.com/valory-xyz/market-resolver/blob/main/packages/packages.json#L33" target="_blank">Link</a>| omen_protocol
+    market_creator -->|<a href="https://github.com/valory-xyz/market-creator/blob/main/pyproject.toml#L59" target="_blank">Link</a>| tomte
+    market_resolver -->|<a href="https://github.com/valory-xyz/market-resolver/blob/main/pyproject.toml#L64" target="_blank">Link</a>| genai
+    market_resolver -->|<a href="https://github.com/valory-xyz/market-resolver/blob/main/pyproject.toml#L62" target="_blank">Link</a>| mech_interact
+    market_resolver -->|<a href="https://github.com/valory-xyz/market-resolver/blob/main/pyproject.toml#L63" target="_blank">Link</a>| omen_protocol
     market_resolver -->|<a href="https://github.com/valory-xyz/market-resolver/blob/main/pyproject.toml#L18" target="_blank">Link</a>| open_aea
     market_resolver -->|<a href="https://github.com/valory-xyz/market-resolver/blob/main/pyproject.toml#L13" target="_blank">Link</a>| open_autonomy
+    market_resolver -->|<a href="https://github.com/valory-xyz/market-resolver/blob/main/pyproject.toml#L52" target="_blank">Link</a>| tomte
     mech -->|<a href="https://github.com/valory-xyz/mech/blob/main/pyproject.toml#L15" target="_blank">Link</a>| open_aea
     mech -->|<a href="https://github.com/valory-xyz/mech/blob/main/pyproject.toml#L14" target="_blank">Link</a>| open_autonomy
-    mech_agents_fun -->|<a href="https://github.com/valory-xyz/mech-agents-fun/blob/main/packages/packages.json#L21" target="_blank">Link</a>| mech
+    mech -->|<a href="https://github.com/valory-xyz/mech/blob/main/pyproject.toml#L50" target="_blank">Link</a>| tomte
+    mech_agents_fun -->|<a href="https://github.com/valory-xyz/mech-agents-fun/blob/main/pyproject.toml#L59" target="_blank">Link</a>| mech
     mech_agents_fun -->|<a href="https://github.com/valory-xyz/mech-agents-fun/blob/main/pyproject.toml#L13" target="_blank">Link</a>| open_aea
     mech_agents_fun -->|<a href="https://github.com/valory-xyz/mech-agents-fun/blob/main/pyproject.toml#L14" target="_blank">Link</a>| open_autonomy
+    mech_agents_fun -->|<a href="https://github.com/valory-xyz/mech-agents-fun/blob/main/pyproject.toml#L64" target="_blank">Link</a>| tomte
     mech_client -->|<a href="https://github.com/valory-xyz/mech-client/blob/main/pyproject.toml#L13" target="_blank">Link</a>| olas_operate_middleware
     mech_client -->|<a href="https://github.com/valory-xyz/mech-client/blob/main/packages/packages.json#L8" target="_blank">Link</a>| open_aea
     mech_client -->|<a href="https://github.com/valory-xyz/mech-client/blob/main/pyproject.toml#L9" target="_blank">Link</a>| open_autonomy
+    mech_client -->|<a href="https://github.com/valory-xyz/mech-client/blob/main/pyproject.toml#L33" target="_blank">Link</a>| tomte
     mech_interact -->|<a href="https://github.com/valory-xyz/mech-interact/blob/main/pyproject.toml#L14" target="_blank">Link</a>| open_aea
     mech_interact -->|<a href="https://github.com/valory-xyz/mech-interact/blob/main/pyproject.toml#L13" target="_blank">Link</a>| open_autonomy
-    mech_predict -->|<a href="https://github.com/valory-xyz/mech-predict/blob/main/packages/packages.json#L32" target="_blank">Link</a>| mech
+    mech_interact -->|<a href="https://github.com/valory-xyz/mech-interact/blob/main/pyproject.toml#L50" target="_blank">Link</a>| tomte
+    mech_predict -->|<a href="https://github.com/valory-xyz/mech-predict/blob/main/pyproject.toml#L6" target="_blank">Link</a>| mech
     mech_predict -->|<a href="https://github.com/valory-xyz/mech-predict/blob/main/pyproject.toml#L13" target="_blank">Link</a>| open_aea
     mech_predict -->|<a href="https://github.com/valory-xyz/mech-predict/blob/main/pyproject.toml#L14" target="_blank">Link</a>| open_autonomy
-    mech_server -->|<a href="https://github.com/valory-xyz/mech-server/blob/main/packages/packages.json#L8" target="_blank">Link</a>| mech
+    mech_predict -->|<a href="https://github.com/valory-xyz/mech-predict/blob/main/pyproject.toml#L91" target="_blank">Link</a>| tomte
+    mech_server -->|<a href="https://github.com/valory-xyz/mech-server/blob/main/pyproject.toml#L6" target="_blank">Link</a>| mech
     mech_server -->|<a href="https://github.com/valory-xyz/mech-server/blob/main/pyproject.toml#L47" target="_blank">Link</a>| mech_client
     mech_server -->|<a href="https://github.com/valory-xyz/mech-server/blob/main/pyproject.toml#L43" target="_blank">Link</a>| olas_operate_middleware
     mech_server -->|<a href="https://github.com/valory-xyz/mech-server/blob/main/pyproject.toml#L13" target="_blank">Link</a>| open_aea
     mech_server -->|<a href="https://github.com/valory-xyz/mech-server/blob/main/pyproject.toml#L14" target="_blank">Link</a>| open_autonomy
-    meme_ooorr -->|<a href="https://github.com/valory-xyz/meme-ooorr/blob/main/packages/packages.json#L64" target="_blank">Link</a>| funds_manager
-    meme_ooorr -->|<a href="https://github.com/valory-xyz/meme-ooorr/blob/main/packages/packages.json#L24" target="_blank">Link</a>| genai
-    meme_ooorr -->|<a href="https://github.com/valory-xyz/meme-ooorr/blob/main/packages/packages.json#L25" target="_blank">Link</a>| kv_store
-    meme_ooorr -->|<a href="https://github.com/valory-xyz/meme-ooorr/blob/main/packages/packages.json#L35" target="_blank">Link</a>| mech_interact
+    mech_server -->|<a href="https://github.com/valory-xyz/mech-server/blob/main/pyproject.toml#L66" target="_blank">Link</a>| tomte
+    meme_ooorr -->|<a href="https://github.com/valory-xyz/meme-ooorr/blob/main/pyproject.toml#L64" target="_blank">Link</a>| funds_manager
+    meme_ooorr -->|<a href="https://github.com/valory-xyz/meme-ooorr/blob/main/pyproject.toml#L62" target="_blank">Link</a>| genai
+    meme_ooorr -->|<a href="https://github.com/valory-xyz/meme-ooorr/blob/main/pyproject.toml#L63" target="_blank">Link</a>| kv_store
+    meme_ooorr -->|<a href="https://github.com/valory-xyz/meme-ooorr/blob/main/pyproject.toml#L61" target="_blank">Link</a>| mech_interact
     meme_ooorr -->|<a href="https://github.com/valory-xyz/meme-ooorr/blob/main/pyproject.toml#L14" target="_blank">Link</a>| open_aea
     meme_ooorr -->|<a href="https://github.com/valory-xyz/meme-ooorr/blob/main/pyproject.toml#L13" target="_blank">Link</a>| open_autonomy
+    meme_ooorr -->|<a href="https://github.com/valory-xyz/meme-ooorr/blob/main/pyproject.toml#L51" target="_blank">Link</a>| tomte
     olas_operate_app -->|<a href="https://github.com/valory-xyz/olas-operate-app/blob/main/pyproject.toml#L13" target="_blank">Link</a>| olas_operate_middleware
     olas_operate_app -->|<a href="https://github.com/valory-xyz/olas-operate-app/blob/main/pyproject.toml#L15" target="_blank">Link</a>| open_aea
     olas_operate_app -->|<a href="https://github.com/valory-xyz/olas-operate-app/blob/main/pyproject.toml#L14" target="_blank">Link</a>| open_autonomy
     olas_operate_middleware -->|<a href="https://github.com/valory-xyz/olas-operate-middleware/blob/main/pyproject.toml#L14" target="_blank">Link</a>| open_aea
     olas_operate_middleware -->|<a href="https://github.com/valory-xyz/olas-operate-middleware/blob/main/pyproject.toml#L13" target="_blank">Link</a>| open_autonomy
+    olas_operate_middleware -->|<a href="https://github.com/valory-xyz/olas-operate-middleware/blob/main/pyproject.toml#L40" target="_blank">Link</a>| tomte
     olas_sdk_starter -->|<a href="https://github.com/valory-xyz/olas-sdk-starter/blob/main/packages/packages.json#L8" target="_blank">Link</a>| open_aea
     olas_sdk_starter -->|<a href="https://github.com/valory-xyz/olas-sdk-starter/blob/main/pyproject.toml#L9" target="_blank">Link</a>| open_autonomy
+    olas_sdk_starter -->|<a href="https://github.com/valory-xyz/olas-sdk-starter/blob/main/pyproject.toml#L14" target="_blank">Link</a>| tomte
     omen_protocol -->|<a href="https://github.com/valory-xyz/omen-protocol/blob/main/pyproject.toml#L18" target="_blank">Link</a>| open_aea
     omen_protocol -->|<a href="https://github.com/valory-xyz/omen-protocol/blob/main/pyproject.toml#L13" target="_blank">Link</a>| open_autonomy
+    omen_protocol -->|<a href="https://github.com/valory-xyz/omen-protocol/blob/main/pyproject.toml#L49" target="_blank">Link</a>| tomte
+    open_aea -->|<a href="https://github.com/valory-xyz/open-aea/blob/main/pyproject.toml#L57" target="_blank">Link</a>| tomte
     open_autonomy -->|<a href="https://github.com/valory-xyz/open-autonomy/blob/main/setup.py#L32" target="_blank">Link</a>| open_aea
-    optimus -->|<a href="https://github.com/valory-xyz/optimus/blob/main/packages/packages.json#L64" target="_blank">Link</a>| funds_manager
-    optimus -->|<a href="https://github.com/valory-xyz/optimus/blob/main/packages/packages.json#L40" target="_blank">Link</a>| genai
-    optimus -->|<a href="https://github.com/valory-xyz/optimus/blob/main/packages/packages.json#L41" target="_blank">Link</a>| kv_store
+    open_autonomy -->|<a href="https://github.com/valory-xyz/open-autonomy/blob/main/pyproject.toml#L107" target="_blank">Link</a>| tomte
+    optimus -->|<a href="https://github.com/valory-xyz/optimus/blob/main/pyproject.toml#L70" target="_blank">Link</a>| funds_manager
+    optimus -->|<a href="https://github.com/valory-xyz/optimus/blob/main/pyproject.toml#L68" target="_blank">Link</a>| genai
+    optimus -->|<a href="https://github.com/valory-xyz/optimus/blob/main/pyproject.toml#L69" target="_blank">Link</a>| kv_store
+    optimus -->|<a href="https://github.com/valory-xyz/optimus/blob/main/pyproject.toml#L67" target="_blank">Link</a>| mech_interact
     optimus -->|<a href="https://github.com/valory-xyz/optimus/blob/main/pyproject.toml#L14" target="_blank">Link</a>| open_aea
     optimus -->|<a href="https://github.com/valory-xyz/optimus/blob/main/pyproject.toml#L13" target="_blank">Link</a>| open_autonomy
+    optimus -->|<a href="https://github.com/valory-xyz/optimus/blob/main/pyproject.toml#L50" target="_blank">Link</a>| tomte
     pettai_agent -->|<a href="https://github.com/valory-xyz/pettai-agent/blob/main/olas-sdk-starter/Pipfile#L7" target="_blank">Link</a>| open_aea
     pettai_agent -->|<a href="https://github.com/valory-xyz/pettai-agent/blob/main/olas-sdk-starter/Pipfile#L13" target="_blank">Link</a>| open_autonomy
     pettai_agent -->|<a href="https://github.com/valory-xyz/pettai-agent/blob/main/olas-sdk-starter/Pipfile#L48" target="_blank">Link</a>| tomte
     propel_client -->|<a href="https://github.com/valory-xyz/propel-client/blob/main/pyproject.toml#L14" target="_blank">Link</a>| open_autonomy
+    propel_client -->|<a href="https://github.com/valory-xyz/propel-client/blob/main/pyproject.toml#L21" target="_blank">Link</a>| tomte
     quickstart -->|<a href="https://github.com/valory-xyz/quickstart/blob/main/pyproject.toml#L14" target="_blank">Link</a>| olas_operate_middleware
     quickstart -->|<a href="https://github.com/valory-xyz/quickstart/blob/main/pyproject.toml#L22" target="_blank">Link</a>| open_aea
     quickstart -->|<a href="https://github.com/valory-xyz/quickstart/blob/main/pyproject.toml#L24" target="_blank">Link</a>| open_autonomy
-    trader -->|<a href="https://github.com/valory-xyz/trader/blob/main/packages/packages.json#L72" target="_blank">Link</a>| funds_manager
-    trader -->|<a href="https://github.com/valory-xyz/trader/blob/main/packages/packages.json#L32" target="_blank">Link</a>| genai
-    trader -->|<a href="https://github.com/valory-xyz/trader/blob/main/packages/packages.json#L44" target="_blank">Link</a>| mech_interact
-    trader -->|<a href="https://github.com/valory-xyz/trader/blob/main/packages/packages.json#L34" target="_blank">Link</a>| omen_protocol
+    trader -->|<a href="https://github.com/valory-xyz/trader/blob/main/pyproject.toml#L85" target="_blank">Link</a>| funds_manager
+    trader -->|<a href="https://github.com/valory-xyz/trader/blob/main/pyproject.toml#L83" target="_blank">Link</a>| genai
+    trader -->|<a href="https://github.com/valory-xyz/trader/blob/main/pyproject.toml#L84" target="_blank">Link</a>| kv_store
+    trader -->|<a href="https://github.com/valory-xyz/trader/blob/main/pyproject.toml#L82" target="_blank">Link</a>| mech_interact
+    trader -->|<a href="https://github.com/valory-xyz/trader/blob/main/pyproject.toml#L86" target="_blank">Link</a>| omen_protocol
     trader -->|<a href="https://github.com/valory-xyz/trader/blob/main/pyproject.toml#L14" target="_blank">Link</a>| open_aea
     trader -->|<a href="https://github.com/valory-xyz/trader/blob/main/pyproject.toml#L13" target="_blank">Link</a>| open_autonomy
+    trader -->|<a href="https://github.com/valory-xyz/trader/blob/main/pyproject.toml#L59" target="_blank">Link</a>| tomte
 
 ```

--- a/scripts/create_dependency_graph.py
+++ b/scripts/create_dependency_graph.py
@@ -550,13 +550,20 @@ def build_repo_contexts(client: GitHubClient, org: str, repos: Iterable[Repo], v
 
 
 def first_line_for_alias(text: str, aliases: Iterable[str]) -> Optional[int]:
-    """Find first line containing any alias using token boundaries."""
+    """Find first non-comment line containing any alias using token boundaries.
+
+    Comment lines (`#`-prefixed, the comment syntax of every dependency-file
+    format scanned here) are skipped so evidence URLs anchor to the actual
+    declaration rather than a comment that merely names the dependency.
+    """
 
     patterns = [
         re.compile(rf"(?<![a-z0-9]){re.escape(alias)}(?![a-z0-9])")
         for alias in aliases
     ]
     for index, line in enumerate(text.splitlines(), start=1):
+        if line.lstrip().startswith("#"):
+            continue
         lowered = line.lower()
         for pattern in patterns:
             if pattern.search(lowered):
@@ -564,16 +571,25 @@ def first_line_for_alias(text: str, aliases: Iterable[str]) -> Optional[int]:
     return None
 
 
-def extract_dependencies_from_toml(text: str) -> List[str]:
-    """Extract dependency package names from pyproject.toml."""
+def extract_dependencies_from_toml(text: str, source: str = "") -> List[str]:
+    """Extract dependency names from pyproject.toml.
+
+    Covers Poetry, PEP 621, PEP 735 dependency groups, and the repository
+    names referenced by `[tool.tomte].upstream_pins`. `source` (e.g.
+    `repo/path`) is used only to label TOML parse errors on stderr.
+    """
     if tomllib is None:
         return []
-    
+
     try:
         data = tomllib.loads(text)
-    except Exception:
+    except Exception as exc:
+        print(
+            f"[parse-fail] {source or 'pyproject.toml'}: invalid TOML ({exc})",
+            file=sys.stderr,
+        )
         return []
-    
+
     deps = set()
     
     # Poetry format
@@ -632,38 +648,19 @@ def extract_dependencies_from_toml(text: str) -> List[str]:
                     if name and name != "python":
                         deps.add(name)
 
-    return sorted(deps)
-
-
-def extract_upstream_pins_from_toml(text: str) -> List[str]:
-    """Extract upstream repository names from `[tool.tomte].upstream_pins`.
-
-    Entries look like `valory-xyz/mech-interact@v0.32.0`; only the repository
-    name is returned. These are explicit cross-repo version pins introduced
-    by uv-era tomte configuration.
-    """
-    if tomllib is None:
-        return []
-    try:
-        data = tomllib.loads(text)
-    except Exception:
-        return []
-
+    # [tool.tomte].upstream_pins: explicit cross-repo version pins. Entries
+    # look like `valory-xyz/mech-interact@v0.32.0`; keep only the repo name.
     tool = data.get("tool", {}) if isinstance(data, dict) else {}
     tomte = tool.get("tomte", {}) if isinstance(tool, dict) else {}
     pins = tomte.get("upstream_pins", []) if isinstance(tomte, dict) else []
-    if not isinstance(pins, list):
-        return []
+    if isinstance(pins, list):
+        for pin in pins:
+            if isinstance(pin, str):
+                repo = pin.split("@")[0].strip().split("/")[-1].strip()
+                if repo:
+                    deps.add(repo)
 
-    repos: Set[str] = set()
-    for pin in pins:
-        if not isinstance(pin, str):
-            continue
-        # Format: [<org>/]<repo>[@<ref>]
-        repo = pin.split("@")[0].strip().split("/")[-1].strip()
-        if repo:
-            repos.add(repo)
-    return sorted(repos)
+    return sorted(deps)
 
 
 def extract_dependencies_from_pipfile(text: str) -> List[str]:
@@ -918,9 +915,9 @@ def infer_edges_from_mentions(
             # Extract dependencies based on file type
             file_deps: List[str] = []
             if path.endswith("pyproject.toml"):
-                file_deps = extract_dependencies_from_toml(text)
-                # [tool.tomte].upstream_pins names valory repos directly.
-                file_deps += extract_upstream_pins_from_toml(text)
+                file_deps = extract_dependencies_from_toml(
+                    text, source=f"{source_ctx.repo.name}/{path}"
+                )
             elif path.endswith("setup.py"):
                 file_deps = extract_dependencies_from_setup_py(text)
             elif path.endswith("package.json"):

--- a/scripts/create_dependency_graph.py
+++ b/scripts/create_dependency_graph.py
@@ -22,7 +22,8 @@
 Rules implemented:
 1) List all non-archived repos from the target org.
 2) Infer dependencies from dependency-oriented files when a repo name or package alias
-   (derived from `packages/packages.json` -> `dev` keys) is mentioned.
+   (derived from `packages/packages.json` -> `dev` keys) is mentioned. This includes
+   explicit cross-repo pins under `[tool.tomte].upstream_pins` in `pyproject.toml`.
 3) Infer dependencies from `packages/packages.json` where repo B `third_party` keys
    reference repo A `dev` keys.
 
@@ -244,6 +245,19 @@ def normalize_alias(value: str) -> str:
     """Normalize an alias token for deterministic matching."""
 
     return value.strip().lower().replace("_", "-")
+
+
+def requirement_name(spec: str) -> str:
+    """Extract the bare package name from a PEP 508 requirement string.
+
+    Handles version specifiers, extras (`pkg[extra]`), environment markers
+    (`pkg; python_version < '3.11'`), and PEP 508 direct references
+    (`pkg @ git+https://...`). Returns an empty string if no name is found.
+    """
+
+    head = spec.split(";")[0].split("@")[0]
+    match = re.match(r"\s*([A-Za-z0-9][A-Za-z0-9._-]*)", head)
+    return match.group(1) if match else ""
 
 
 def node_id(repo_name: str) -> str:
@@ -572,16 +586,84 @@ def extract_dependencies_from_toml(text: str) -> List[str]:
         if "dev-dependencies" in poetry and isinstance(poetry["dev-dependencies"], dict):
             for key in poetry["dev-dependencies"].keys():
                 deps.add(key)
-    
-    # PEP 621 format
-    if "project" in data and "dependencies" in data["project"]:
-        if isinstance(data["project"]["dependencies"], list):
-            for dep in data["project"]["dependencies"]:
-                pkg_name = dep.split(";")[0].split("[")[0].split("=")[0].split("<")[0].split(">")[0].split("!")[0].split("~")[0].strip()
-                if pkg_name:
-                    deps.add(pkg_name)
-    
+        # Poetry 1.2+ dependency groups: [tool.poetry.group.<name>.dependencies]
+        groups = poetry.get("group")
+        if isinstance(groups, dict):
+            for group in groups.values():
+                if not isinstance(group, dict):
+                    continue
+                group_deps = group.get("dependencies")
+                if isinstance(group_deps, dict):
+                    for key in group_deps.keys():
+                        if key != "python":
+                            deps.add(key)
+
+    # PEP 621 format: [project.dependencies] and [project.optional-dependencies]
+    project = data.get("project")
+    if isinstance(project, dict):
+        project_deps = project.get("dependencies")
+        if isinstance(project_deps, list):
+            for dep in project_deps:
+                if isinstance(dep, str):
+                    name = requirement_name(dep)
+                    if name and name != "python":
+                        deps.add(name)
+        optional = project.get("optional-dependencies")
+        if isinstance(optional, dict):
+            for extra in optional.values():
+                if not isinstance(extra, list):
+                    continue
+                for dep in extra:
+                    if isinstance(dep, str):
+                        name = requirement_name(dep)
+                        if name and name != "python":
+                            deps.add(name)
+
+    # PEP 735 dependency groups: top-level [dependency-groups] (used by uv)
+    dependency_groups = data.get("dependency-groups")
+    if isinstance(dependency_groups, dict):
+        for group in dependency_groups.values():
+            if not isinstance(group, list):
+                continue
+            for item in group:
+                # String entries are requirements; dicts are {include-group: ...}.
+                if isinstance(item, str):
+                    name = requirement_name(item)
+                    if name and name != "python":
+                        deps.add(name)
+
     return sorted(deps)
+
+
+def extract_upstream_pins_from_toml(text: str) -> List[str]:
+    """Extract upstream repository names from `[tool.tomte].upstream_pins`.
+
+    Entries look like `valory-xyz/mech-interact@v0.32.0`; only the repository
+    name is returned. These are explicit cross-repo version pins introduced
+    by uv-era tomte configuration.
+    """
+    if tomllib is None:
+        return []
+    try:
+        data = tomllib.loads(text)
+    except Exception:
+        return []
+
+    tool = data.get("tool", {}) if isinstance(data, dict) else {}
+    tomte = tool.get("tomte", {}) if isinstance(tool, dict) else {}
+    pins = tomte.get("upstream_pins", []) if isinstance(tomte, dict) else []
+    if not isinstance(pins, list):
+        return []
+
+    repos: Set[str] = set()
+    for pin in pins:
+        if not isinstance(pin, str):
+            continue
+        # Format: [<org>/]<repo>[@<ref>]
+        repo = pin.split("@")[0].strip().split("/")[-1].strip()
+        if repo:
+            repos.add(repo)
+    return sorted(repos)
 
 
 def extract_dependencies_from_pipfile(text: str) -> List[str]:
@@ -837,6 +919,8 @@ def infer_edges_from_mentions(
             file_deps: List[str] = []
             if path.endswith("pyproject.toml"):
                 file_deps = extract_dependencies_from_toml(text)
+                # [tool.tomte].upstream_pins names valory repos directly.
+                file_deps += extract_upstream_pins_from_toml(text)
             elif path.endswith("setup.py"):
                 file_deps = extract_dependencies_from_setup_py(text)
             elif path.endswith("package.json"):


### PR DESCRIPTION
## What

`scripts/create_dependency_graph.py` was silently dropping real dependencies because it only understood dependency-file formats that pre-date the org's tooling migration. This PR fixes the parser and regenerates `docs/dependency_graph.md`.

No new functionality — the dependency graph already exists on `main`; this only corrects edges it was missing.

## Why

The valory-xyz repos migrated from Poetry to uv and bumped Poetry versions. That introduced dependency-declaration formats the generator never parsed, so any dependency declared in them was omitted from the graph. For example `open-aea → tomte` — and ~20 other `→ tomte` edges — were missing entirely.

## What's fixed

| Format | Problem | Affected repos |
|--------|---------|----------------|
| `[tool.poetry.group.*.dependencies]` | Poetry 1.2+ dependency groups never parsed — only the legacy flat `[tool.poetry.dependencies]` / `[tool.poetry.dev-dependencies]` were | open-aea, open-autonomy, mech-client, mech-server |
| `[dependency-groups]` | PEP 735 group table never parsed at all — every uv repo lost its dev/test deps | all uv-migrated repos |
| `[project.optional-dependencies]` | PEP 621 extras table never parsed | PEP 621 repos using extras |
| `name @ git+url` | PEP 508 direct references mis-parsed — the whole URL was kept as the "package name" | uv repos pinning to git (e.g. `tomte`) |
| `[tool.tomte].upstream_pins` | explicit cross-repo version pins were ignored | repos with tomte upstream pins (e.g. trader) |

A new `requirement_name()` helper does robust PEP 508 name extraction (extras, version specifiers, environment markers, direct references).

## Result

`docs/dependency_graph.md` regenerated — 55 repos, 110 edges. Recovered edges include `open-aea → tomte`, `tomte` links from ~20 more repos, and `trader`'s upstream-pin edges to mech-interact / genai / kv-store / funds-manager / omen-protocol.

## Test plan

- [x] `python scripts/create_dependency_graph.py` reproduces `docs/dependency_graph.md` (deterministic output)
- [x] Dependency Graph page renders the Mermaid chart with working node links
- [x] `tox -e docs` builds cleanly
